### PR TITLE
🐛 ci: fix concurrency group for publish new docs version

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -1,6 +1,8 @@
 name: Update versioned docs
 
-concurrency: update-docs-${{ github.ref }}
+concurrency:
+  group: update-docs-${{ github.ref }}
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Try to fix the issue with concurrency job when publish a new axoned release that trigger multiple `update-versioned-docs` jobs at the same time. By default `cancel-in-progress` param is `true`, try to set to `false` and avoid cancelling in progress jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Improved concurrency control in documentation update workflow to prevent cancellations of in-progress updates.
  - Modified concurrency settings in workflow for better control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->