### PR TITLE
Ci/fix update versionned docs

### DIFF
--- a/.github/workflows/bump-axoned-version.yml
+++ b/.github/workflows/bump-axoned-version.yml
@@ -39,4 +39,4 @@ jobs:
           commit_user_name: ${{ vars.BOT_GIT_COMMITTER_NAME }}
           commit_user_email: ${{ vars.BOT_GIT_COMMITTER_EMAIL }}
           commit_author: ${{ vars.BOT_GIT_AUTHOR_NAME }} <${{ vars.BOT_GIT_AUTHOR_EMAIL }}>
-          commit_message: "build: bump zxoned version to ${{ github.event.inputs.axonedVersion }}"
+          commit_message: "build: bump axoned version to ${{ github.event.inputs.axonedVersion }}"

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -1,8 +1,8 @@
 name: Update versioned docs
 
 concurrency:
-  group: update-docs-${{ github.ref }}
-  cancel-in-progress: false
+  group: update-docs-${{ github.ref }}-${{ github.event.inputs.section }}
+  cancel-in-progress: ${{ github.event.inputs.draft == 'true' }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -14,7 +14,7 @@ on:
         description: "Set the repository that docs has been updated (axone-protocol/contracts | axone-protocol/axoned)"
         required: true
       section:
-        description: "Which section will be update (contracts | modules | commands)"
+        description: "Which section will be update (contracts | modules | commands | predicates)"
         required: true
       docs_directory:
         description: "On which directory documentation is located (docs/* | docs/proto/* | docs/command/*)"


### PR DESCRIPTION
This PR introduces several fixes and improvements:

- Corrected a typographical error in the commit message that is sent when a new version of the documentation is pushed.

- Addressed a perceived concurrency issue which should have been fixed by #498. This was not an actual issue, but rather a feature of GitHub Actions where pending workflows with the same group ID are cancelled when `cancel-in-progress` is set to `false`. A request has been made to the [GitHub community](https://github.com/orgs/community/discussions/41518) in 2022 to add a new parameter `cancel-pending` that would allow pending workflows to wait instead of being cancelled. More details can be found [here](https://taurit.pl/github-canceling-since-a-higher-priority-waiting-request-exists/).

  As a workaround, the `section` name has been added to the group ID, allowing one section to be built at a time. Since no common file is edited when publishing a new version of the documentation for each section, and changes are introduced via PRs rather than direct pushes, this should not cause any issues. Additionally, `cancel-in-progress` has been set back to `true` for drafts, with the section linked through the group ID.

- Added the `predicates` section to the input examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Corrected a typo in the commit message for the GitHub workflow related to bumping the "axoned" version.
  - Updated the concurrency group name and added conditional cancellation in the workflow for updating versioned docs.
  - Introduced a new "predicates" section option in the versioned docs update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->