### PR TITLE
fix: repair broken image URLs

### DIFF
--- a/docs/architecture/governance/hierarchy-of-norms.md
+++ b/docs/architecture/governance/hierarchy-of-norms.md
@@ -9,7 +9,7 @@ The hierarchy of norms refers to the hierarchical structure of rules within the 
 In the Axone Governance framework, the hierarchy of norms establishes a clear order of precedence for rules and regulations. We thus end up with different levels of governance that allow fine-grained control of the use of the protocol.
 
 <div style={{ display: "flex", justifyContent: "center" }}>
-  <img src="/img/content/architecture/governance-hierarchy-of-norms.webp" alt="Governance - Hierarchy of Norms" style={{ maxHeight: "340px" }}></img>
+  <img src="/img/content/technical-documentation/governance-hierarchy-of-norms.webp" alt="Governance - Hierarchy of Norms" style={{ maxHeight: "340px" }}></img>
 </div>
 
 <br/>

--- a/docs/architecture/ontology/the-power-of-ontologies.md
+++ b/docs/architecture/ontology/the-power-of-ontologies.md
@@ -29,7 +29,7 @@ Several languages are used to express the Axone ontologies:
 - [SKOS (Simple Knowledge Organization System)](https://en.wikipedia.org/wiki/Simple_Knowledge_Organization_System): a language for representing ontology that allows the description of classification systems and thesauri. SKOS allows the definition of concepts, relationships, and properties.
 
 <div style={{ display: "flex", justifyContent: "center" }}>
-  <img src="/img/content/architecture/semantic-stack.webp" style={{ maxHeight: "335px" }}></img>
+  <img src="/img/content/technical-documentation/semantic-stack.webp" style={{ maxHeight: "335px" }}></img>
 </div>
 
 ## Ontology at the heart of the blockchain

--- a/docs/architecture/ontology/what-are-ontologies.md
+++ b/docs/architecture/ontology/what-are-ontologies.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 In computer science, ontology is a formal and structured representation of the concepts, relationships, and properties of a particular domain. An ontology generally comprises the following basic elements: concepts, relationships, properties, axioms, and instances. These can be graphically represented by the simplified equation shown below.
 
 <div style={{ display: "flex", justifyContent: "center" }}>
-  <img src="/img/content/architecture/ontology_equation.webp" alt="Ontology equation" style={{ maxHeight: "220px" }}></img>
+  <img src="/img/content/technical-documentation/ontology_equation.webp" alt="Ontology equation" style={{ maxHeight: "220px" }}></img>
 </div>
 
 Some definitions:
@@ -111,7 +111,7 @@ The construction of this ontology follows a number of steps which are described 
 - **Ontology evaluation (6)**: Association of key concepts and terms in the ontology with concepts and terms of other ontologies.
 
 <div style={{ display: "flex", justifyContent: "center" }}>
-  <img src="/img/content/architecture/ontology-construction-process.webp" alt="Ontology construction process" style={{ maxHeight: "650px" }}></img>
+  <img src="/img/content/technical-documentation/ontology-construction-process.webp" alt="Ontology construction process" style={{ maxHeight: "650px" }}></img>
 </div>
 
 ## Underlying Assumptions


### PR DESCRIPTION
Self explanatory.

<img width="829" alt="image" src="https://github.com/user-attachments/assets/b2edbb5e-36bb-4b08-8223-26af092025a3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated image source paths in the "Hierarchy of Norms" and "The Power of Ontologies" documents to reflect a new file organization.
	- Enhanced clarity and readability in the "The Power of Ontologies" document while maintaining core content.
	- Revised image sources in the "What Are Ontologies" document without altering any text or structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->