### PR TITLE
fix(api-reference): correct link to ontology

### DIFF
--- a/docs/api-reference/api-reference.mdx
+++ b/docs/api-reference/api-reference.mdx
@@ -86,7 +86,7 @@ Apprehend the Axone Ontology and Prolog Predicates to help you describe and secu
   <div class="row row-cols-1 row-cols-md-2a g-3">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/predicates/bank_balances_2" class="card-title card-link stretched-link">
+        <a href="/ontology/schemas/credential-dataset-description" class="card-title card-link stretched-link">
           <h2>Ontology</h2>
         </a>
         <p class="card-text">Discover the semantic power of the Ontology to enhance the dataverse.</p>


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hyperlink in the "Ontology" section of the API reference documentation to reflect a broader schema description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->