### PR TITLE
docs(README): fix vercel deployment badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![lint](https://img.shields.io/github/actions/workflow/status/axone-protocol/docs/lint.yml?label=lint&style=for-the-badge&logo=github)](https://github.com/axone-protocol/docs/actions/workflows/lint.yml)
 [![build](https://img.shields.io/github/actions/workflow/status/axone-protocol/docs/build.yml?label=build&style=for-the-badge&logo=github)](https://github.com/axone-protocol/docs/actions/workflows/build.yml)
-[![publish](https://img.shields.io/github/actions/workflow/status/axone-protocol/docs/publish.yml?label=publish&style=for-the-badge&logo=github)](https://github.com/axone-protocol/docs/actions/workflows/publish.yml)
+[![vercel deploy](https://deploy-badge.vercel.app/vercel/docs-bgu5cuq5p-axone?style=for-the-badge)](https://docs.axone.xyz/)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/axone-protocol/.github/blob/main/CODE_OF_CONDUCT.md)
 [![prettier](https://img.shields.io/badge/prettier-1A2C34?style=for-the-badge&logo=prettier&logoColor=F7BA3E)](https://github.com/prettier/prettier)


### PR DESCRIPTION
Replace the `publish` badge with the `vercel deploy` badge displaying the deployment status of the production Axone documentation website.